### PR TITLE
Add an UpAll function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ package migrations
 import (
 	"database/sql"
 
-	"github.com/pressly/goose"
+	"github.com/braincorp/goose"
 )
 
 func init() {

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/pressly/goose"
+	"github.com/braincorp/goose"
 )
 
 var (

--- a/create.go
+++ b/create.go
@@ -72,7 +72,7 @@ var goSQLMigrationTemplate = template.Must(template.New("goose.go-migration").Pa
 
 import (
 	"database/sql"
-	"github.com/pressly/goose"
+	"github.com/braincorp/goose"
 )
 
 func init() {

--- a/examples/go-migrations/00002_rename_root.go
+++ b/examples/go-migrations/00002_rename_root.go
@@ -3,7 +3,7 @@ package main
 import (
 	"database/sql"
 
-	"github.com/pressly/goose"
+	"github.com/braincorp/goose"
 )
 
 func init() {

--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/pressly/goose"
+	"github.com/braincorp/goose"
 
 	_ "github.com/mattn/go-sqlite3"
 )


### PR DESCRIPTION
Applies all migrations, not just those newer than the latest point.